### PR TITLE
Use definitive path for bash

### DIFF
--- a/gnome-magic-window
+++ b/gnome-magic-window
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 # Copyright 2017 Adrien Vergé
 
 set -eu


### PR DESCRIPTION
On systems with usrmerge bash can be found as /bin/bash or
/usr/bin/bash.

On systems without usrmerge bash may only be available as /bin/bash.

Use the path that works in both cases.