### PR TITLE
Ignore windows without titles

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -91,7 +91,7 @@ class Extension {
            .map(w => ({id: w.toString(),
                        ref: w,
                        title: w.get_meta_window().get_wm_class()}))
-           .filter(w => !w.title.includes('Gnome-shell'));
+           .filter(w => w.title != null && !w.title.includes('Gnome-shell'));
   }
 
   get_active_window() {

--- a/extension.js
+++ b/extension.js
@@ -91,7 +91,7 @@ class Extension {
            .map(w => ({id: w.toString(),
                        ref: w,
                        title: w.get_meta_window().get_wm_class()}))
-           .filter(w => w.title != null && !w.title.includes('Gnome-shell'));
+           .filter(w => w.title && !w.title.includes('Gnome-shell'));
   }
 
   get_active_window() {


### PR DESCRIPTION
Thunderbird displays "tooltip" popup windows containing the complete subject line of the message under the mouse pointer. These windows have `w.title == null`. Let's ignore such windows rather than causing an exception by trying to call a method on the null.

This means that gnome-magic-window bindings now work for me even when one of these popup windows is active.